### PR TITLE
Remove stray line from digraphstats.py

### DIFF
--- a/frame/digraphstats.py
+++ b/frame/digraphstats.py
@@ -45,4 +45,3 @@ class Digraphstats(object):
           abs_Z_matrix=(abs_Z_triu+abs_Z_triu.T).toarray()
           ax.imshow(abs_Z_matrix, cmap='viridis',interpolation='nearest')
           ax.set_xlabel('|z-score|',fontsize=15)
-   

--- a/frame/digraphstats.py
+++ b/frame/digraphstats.py
@@ -45,5 +45,4 @@ class Digraphstats(object):
           abs_Z_matrix=(abs_Z_triu+abs_Z_triu.T).toarray()
           ax.imshow(abs_Z_matrix, cmap='viridis',interpolation='nearest')
           ax.set_xlabel('|z-score|',fontsize=15)
-                        size=v.obs_node_textsize*0.8, zorder=v.obs_node_zorder,)
    

--- a/frame/loss.py
+++ b/frame/loss.py
@@ -206,5 +206,4 @@ def loss_wrapper(z,M,S,h,p,lamb,deg,k):
     grad_loss= np.append(grad_loss_m,grad_loss_c)                              #Merge the gradient
     grad_loss_z=grad_loss*theta                                                #Gradient with respect to z
 
-    #print(loss)
     return (loss,grad_loss_z)

--- a/frame/spatial_digraph.py
+++ b/frame/spatial_digraph.py
@@ -296,5 +296,3 @@ class SpatialDiGraph(nx.DiGraph):
                    "train_loss={:.7f}\n"
                ).format(lamb,res[2]["nit"], self.train_loss)
            )
-
-

--- a/frame/visualization.py
+++ b/frame/visualization.py
@@ -774,4 +774,3 @@ class Vis(object):
         self.draw_attributes_wrapper([axs[1, 0], axs[1, 1], axs[1, 2],axs[1,3]],
                                      node_scale=node_scale,
                                      draw_map=draw_map)
-       


### PR DESCRIPTION
Hello!

This is a really cool method — I’m looking forward to using it!

I noticed what looks like a stray line at the end of `draw_heatmap` in digraphstats.py:

```python
size=v.obs_node_textsize*0.8, zorder=v.obs_node_zorder,)
```

The line caused an IndentationError, preventing the package from being imported.  This PR just removes the stray line.

Best,

Anusha
